### PR TITLE
Connect to linked services on the correct ports.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
     ssl_stapling_verify on;
 
     location / {
-      proxy_pass http://presenter;
+      proxy_pass http://presenter:8080;
     }
   }
 
@@ -58,7 +58,7 @@ http {
     ssl_stapling_verify on;
 
     location / {
-      proxy_pass http://content;
+      proxy_pass http://content:8080;
     }
   }
 }


### PR DESCRIPTION
Both upstream services listen internally on port 8080, so that's the port
we should connect nginx to.
