### PR TITLE
The content service takes a while to respond sometimes.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -39,6 +39,8 @@ http {
       proxy_pass http://presenter:8080;
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_read_timeout 120s;
+      proxy_send_timeout 120s;
     }
   }
 
@@ -65,6 +67,8 @@ http {
       proxy_pass http://content:8080;
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_read_timeout 120s;
+      proxy_send_timeout 120s;
     }
   }
 }


### PR DESCRIPTION
This increases nginx's proxy timeout to match the one we configure on the load balancers.
