### PR TITLE
Increase client_max_body_size to 10m.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,6 +63,8 @@ http {
     ssl_stapling on;
     ssl_stapling_verify on;
 
+    client_max_body_size 10m;
+
     location / {
       proxy_pass http://content:8080;
       proxy_set_header Host $host;


### PR DESCRIPTION
This will prevent 413s during content builds, like the one from rackerlabs/docs-developer-blog#108.
