### PR TITLE
Work out the kinks for running Strider on Carina

### DIFF
--- a/strider/Dockerfile
+++ b/strider/Dockerfile
@@ -1,22 +1,19 @@
 FROM alpine:3.2
 
-RUN apk add --update nodejs python-dev build-base krb5-dev openssh-client \
+RUN apk add --update nodejs python-dev build-base krb5-dev openssh-client git perl \
   && rm -rf /var/cache/apk/*
 
-RUN adduser -D -g "" -u 1000 strider
-RUN mkdir -p /home/strider/ /workspace/
+RUN mkdir -p /strider/ /workspace/
 
-RUN chown -R strider:strider /home/strider/ /workspace/
-WORKDIR /home/strider/deconst-strider
+WORKDIR /strider/deconst-strider/
 
-ADD deconst-strider/package.json /home/strider/deconst-strider/package.json
+ADD deconst-strider/package.json /strider/deconst-strider/package.json
 RUN npm install
-ADD deconst-strider/ /home/strider/deconst-strider/
+ADD deconst-strider/ /strider/deconst-strider/
 
 EXPOSE 3000
-USER strider
 
-ENV HOME /home/strider
+ENV HOME /strider
 ENV STRIDER_CLONE_DEST /workspace/
 
-ENTRYPOINT ["node", "/home/strider/deconst-strider/index.js"]
+ENTRYPOINT ["node", "/strider/deconst-strider/index.js"]

--- a/strider/deconst-strider/index.js
+++ b/strider/deconst-strider/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var strider = require('strider');
@@ -9,6 +10,9 @@ var user = require('./user');
 var project = require('./project');
 
 var extPath = path.join(__dirname, "node_modules");
+
+process.umask(02);
+fs.chmodSync('/workspace', 06755);
 
 var launchStrider = function (callback) {
   strider(extPath, {}, callback);

--- a/strider/deconst-strider/package.json
+++ b/strider/deconst-strider/package.json
@@ -20,7 +20,7 @@
     "strider-cli": "^1.4.10",
     "strider-custom": "^0.6.0",
     "strider-deconst-content": "^1.0.1",
-    "strider-deconst-control": "^1.0.0",
+    "strider-deconst-control": "^1.0.1",
     "strider-email-notifier": "^0.4.2",
     "strider-env": "^0.5.1",
     "strider-git": "^0.2.4",


### PR DESCRIPTION
Strider's eventual home will be on a Carina cluster (along with the rest of the cluster), so I want to be certain it can run there. One it can run on Carina, it will certainly be able to run on our own CoreOS cluster.

Current problems:
- [x] Strider needs to run as root so that it can launch other Docker containers through the Docker socket.
- [x] `git` and `perl` are needed by the git provider.
### Control repository builds
- [x] `npm` attempts to use root-owned paths for its cache.
  
  ```
  >> Waiting for preparer container completion. { containerId: '7e3b638c1f2f18788edb8e8b2da5b6259031306f4825be3a7e363c2e19bbb924' }
  npm ERR! Linux 3.18.21-1-rackos
  npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "install"
  npm ERR! node v0.12.9
  npm ERR! npm  v2.14.9
  npm ERR! path /var/control-repo/.tmp
  npm ERR! code EACCES
  npm ERR! errno -13
  ```
- [x] Asset preparer runs with admin API key.
### Content repository builds
- [x] Build data directories are owned by root.
  
  ```
  / # cd workspace/
  /workspace # ls -l
  total 2
  drwxr-xr-x    3 1000     1000          1024 Jan 29 20:45 cache
  drwxr-xr-x    3 1000     1000          1024 Jan 29 20:59 data
  /workspace # cd data/
  /workspace/data # ls -l
  total 1
  drwxr-xr-x    7 root     root          1024 Jan 29 20:59 deconst-deconst-docs-56abd2b59d07e50100c91757
  ```
