### PR TITLE
Increase maximum client body size to 100m

### DIFF
--- a/nginx-pod/nginx.conf
+++ b/nginx-pod/nginx.conf
@@ -63,7 +63,7 @@ http {
     ssl_stapling on;
     ssl_stapling_verify on;
 
-    client_max_body_size 10m;
+    client_max_body_size 100m;
 
     location / {
       proxy_pass http://content:8080;


### PR DESCRIPTION
We need this to accept bulk uploads from the submitter:

```
Beginning /bulkasset request.
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/submitter/submitter/__main__.py", line 29, in <module>
    result = submit(c)
  File "/submitter/submitter/submit.py", line 33, in submit
    content_service
  File "/submitter/submitter/submit.py", line 102, in submit_assets
    upload_result = content_service.bulkasset(asset_archive.getvalue())
  File "/submitter/submitter/content_service.py", line 61, in bulkasset
    r.raise_for_status()
  File "/usr/lib/python3.5/site-packages/requests/models.py", line 840, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 413 Client Error: Request Entity Too Large for url: https://developer.rackspace.com:9000/bulkasset
```
